### PR TITLE
add docker file

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:18.04
+LABEL author="Kyle McCann <ylmcc@redbrick.dcu.ie>"
+
+WORKDIR /home/kyle/testing
+COPY . /odin-testing
+
+
+
+# Get some prerequisites
+RUN apt-get update
+RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y tzdata wget build-essential sudo apt-utils systemd
+
+# Install Go
+RUN wget -c https://dl.google.com/go/go1.14.2.linux-amd64.tar.gz -O - | sudo tar -xz -C /usr/local
+ENV PATH=$PATH:/usr/local/go/bin
+RUN go version
+
+# Build Odin
+ENV ODIN_EXEC_ENV True
+ENV ODIN_MONGODB "mongodb://localhost:27017"
+RUN ls /odin-testing
+RUN sudo make /odin-testing
+
+VOLUME ["/home/kyle/testing/"]
+CMD ["/etc/init.d/odin", "start"]


### PR DESCRIPTION
#49 This will build the docker image, some things to note:
This only builds the cli and engine as the UI is being revamped. Once that is done I will look at adding the UI to the image. 

You will need to modify /root/odin-config.yml > mongo > address using the command 
`sed -i 's/localhost:27017/YOUR_MONGO_IP_HERE:MONGO_PORT_HERE/' odin-config.yml	 `

As the yml file is currently like this:
`odin:  
  master: "localhost
  port: "3939"  
mongo:  
  address: "mongodb://localhost:27017"  
`

Once you have edited it, you can restart the container and the change should be persistent.